### PR TITLE
Add -D_SDL_main_h and -DSDL_main_h_

### DIFF
--- a/sdl2-gfx.cabal
+++ b/sdl2-gfx.cabal
@@ -50,6 +50,9 @@ library
 
   default-language:
     Haskell2010
+    
+  if os(windows)
+    cpp-options: -D_SDL_main_h -DSDL_main_h_
 
 flag example
   description: Build the example executable


### PR DESCRIPTION
The lack of these compiler switches prevented SDL2-gfx from linking. After adding this in the .cabal file, everything works.