### PR TITLE
Delete functions that can't be found in sdl_gfx

### DIFF
--- a/src/SDL/ImageFilter.hs
+++ b/src/SDL/ImageFilter.hs
@@ -39,8 +39,6 @@ module SDL.ImageFilter
   , shiftRightUInt
   , multByByte
   , shiftRightAndMultByByte
-  , shiftLeftByte
-  , shiftLeftUInt
   , shiftLeft
   , binarizeUsingThreshold
   , clipToRange
@@ -162,14 +160,8 @@ shiftRight = binaryByte SDL.Raw.ImageFilter.shiftRight
 multByByte :: Word8 -> Vector Word8 -> Vector Word8
 multByByte = binaryByte SDL.Raw.ImageFilter.multByByte
 
-shiftLeftByte :: Word8 -> Vector Word8 -> Vector Word8
-shiftLeftByte = binaryByte SDL.Raw.ImageFilter.shiftLeftByte
-
 shiftRightUInt :: Word8 -> Vector Word8 -> Vector Word8
 shiftRightUInt = binaryByte SDL.Raw.ImageFilter.shiftRightUInt
-
-shiftLeftUInt :: Word8 -> Vector Word8 -> Vector Word8
-shiftLeftUInt = binaryByte SDL.Raw.ImageFilter.shiftLeftUInt
 
 shiftLeft :: Word8 -> Vector Word8 -> Vector Word8
 shiftLeft = binaryByte SDL.Raw.ImageFilter.shiftLeft

--- a/src/SDL/Raw/ImageFilter.hsc
+++ b/src/SDL/Raw/ImageFilter.hsc
@@ -40,8 +40,6 @@ module SDL.Raw.ImageFilter
   , shiftRightUInt
   , multByByte
   , shiftRightAndMultByByte
-  , shiftLeftByte
-  , shiftLeftUInt
   , shiftLeft
   , binarizeUsingThreshold
   , clipToRange
@@ -124,12 +122,6 @@ liftF "multByByte" "SDL_imageFilterMultByByte"
 
 liftF "shiftRightAndMultByByte" "SDL_imageFilterShiftRightAndMultByByte"
   [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> CUChar -> IO CInt|]
-
-liftF "shiftLeftByte" "SDL_imageFilterLeftByte"
-  [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> IO CInt|]
-
-liftF "shiftLeftUInt" "SDL_imageFilterLeftUint"
-  [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> IO CInt|]
 
 liftF "shiftLeft" "SDL_imageFilterShiftLeft"
   [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> IO CInt|]

--- a/src/SDL/Raw/Primitive.hsc
+++ b/src/SDL/Raw/Primitive.hsc
@@ -53,7 +53,6 @@ module SDL.Raw.Primitive
   , polygon
   , aaPolygon
   , filledPolygon
-  , texturedPolygon
   ) where
 
 import Data.Int                (Int16)
@@ -170,9 +169,6 @@ liftF "aaPolygon" "aapolygonRGBA"
 
 liftF "filledPolygon" "filledPolygonRGBA"
   [t|Renderer -> Ptr X -> Ptr Y -> N -> R -> G -> B -> A -> IO CInt|]
-
-liftF "texturedPolygon" "texturedPolygonRGBA"
-  [t|Renderer -> Ptr X -> Ptr Y -> N -> Ptr Surface -> X -> Y -> R -> G -> B -> A -> IO CInt|]
 
 liftF "bezier" "bezierRGBA"
   [t|Renderer -> Ptr X -> Ptr Y -> N -> N -> R -> G -> B -> A -> IO CInt|]

--- a/src/SDL/Raw/Rotozoom.hsc
+++ b/src/SDL/Raw/Rotozoom.hsc
@@ -21,10 +21,7 @@ module SDL.Raw.Rotozoom
   , pattern SMOOTHING_OFF
   , rotozoom
   , rotozoomXY
-  , rotozoomSize
-  , rotozoomSizeXY
   , zoom
-  , zoomSize
   , shrink
   , rotate90
   ) where
@@ -45,17 +42,8 @@ liftF "rotozoom" "rotozoomSurface"
 liftF "rotozoomXY" "rotozoomSurfaceXY"
   [t|Ptr Surface -> CDouble -> CDouble -> CDouble -> CInt -> IO (Ptr Surface)|]
 
-liftF "rotozoomSize" "rotozoomSize"
-  [t|CInt -> CInt -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
-
-liftF "rotozoomSizeXY" "rotozoomSizeXY"
-  [t|CInt -> CInt -> CDouble -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
-
 liftF "zoom" "zoomSurface"
   [t|Ptr Surface -> CDouble -> CDouble -> CInt -> IO (Ptr Surface)|]
-
-liftF "zoomSize" "zoomSize"
-  [t|CInt -> CInt -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
 
 liftF "shrink" "shrinkSurface"
   [t|Ptr Surface -> CInt -> CInt -> IO (Ptr Surface)|]

--- a/src/SDL/Rotozoom.hs
+++ b/src/SDL/Rotozoom.hs
@@ -20,12 +20,8 @@ module SDL.Rotozoom
   , rotozoom
   , rotozoomXY
   , Size
-  , rotozoomSize
-  , rotozoomSizeXY
   , zoom
   , zoomXY
-  , zoomSize
-  , zoomSizeXY
   , shrink
   , rotate90
   ) where
@@ -83,27 +79,6 @@ rotozoomXY (Surface p _) a zx zy s =
 -- | A surface size, packing width and height.
 type Size = V2 CInt
 
--- | Given the 'Size' of an input 'Surface', returns the 'Size' of a 'Surface'
--- resulting from a 'rotozoom' call.
-rotozoomSize :: MonadIO m => Size -> Angle -> Zoom -> m Size
-rotozoomSize (V2 w h) a z =
-  liftIO .
-    alloca $ \w' ->
-      alloca $ \h' -> do
-        SDL.Raw.Rotozoom.rotozoomSize w h (realToFrac a) (realToFrac z) w' h'
-        V2 <$> peek w' <*> peek h'
-
--- | Same as 'rotozoomSize', but for different horizontal and vertical scaling
--- factors.
-rotozoomSizeXY :: MonadIO m => Size -> Angle -> Zoom -> Zoom -> m Size
-rotozoomSizeXY (V2 w h) a zx zy =
-  liftIO .
-    alloca $ \w' ->
-      alloca $ \h' -> do
-        SDL.Raw.Rotozoom.rotozoomSizeXY
-          w h (realToFrac a) (realToFrac zx) (realToFrac zy) w' h'
-        V2 <$> peek w' <*> peek h'
-
 {-# INLINE zoom #-}
 -- | Same as 'rotozoom', but only performs the zoom.
 --
@@ -120,21 +95,6 @@ zoomXY :: MonadIO m => Surface -> Zoom -> Zoom -> Smooth -> m Surface
 zoomXY (Surface p _) zx zy s =
   unmanaged <$>
     SDL.Raw.Rotozoom.zoom p (realToFrac zx) (realToFrac zy) (smoothToCInt s)
-
-{-# INLINE zoomSize #-}
--- | Calculates the 'Size' of a resulting 'Surface' for a 'zoom' call.
-zoomSize :: MonadIO m => Size -> Zoom -> m Size
-zoomSize size z = zoomSizeXY size z z
-
--- | Same as 'zoomSize', but for different horizontal and vertical scaling
--- factors.
-zoomSizeXY :: MonadIO m => Size -> Angle -> Zoom -> m Size
-zoomSizeXY (V2 w h) zx zy =
-  liftIO .
-    alloca $ \w' ->
-      alloca $ \h' -> do
-        SDL.Raw.Rotozoom.zoomSize w h (realToFrac zx) (realToFrac zy) w' h'
-        V2 <$> peek w' <*> peek h'
 
 -- | Shrink a surface by an integer ratio.
 --


### PR DESCRIPTION
I'm hesitant to make this PR because the solution is a little silly, but it worked for my project so maybe this is useful?

Cabal refused to compile my project, claiming it couldn't find these functions in the `.so` file, my solution was to delete these.
This was *not* a type error but a linking error. Maybe I did something wrong, or is this normal?

