### PR TITLE
Update foreign function names to match SDL2_gfx version 1.0.4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
+dist-newstyle/
 *.prof
 *.aux
 *.hp

--- a/src/SDL/Raw/ImageFilter.hsc
+++ b/src/SDL/Raw/ImageFilter.hsc
@@ -125,10 +125,10 @@ liftF "multByByte" "SDL_imageFilterMultByByte"
 liftF "shiftRightAndMultByByte" "SDL_imageFilterShiftRightAndMultByByte"
   [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> CUChar -> IO CInt|]
 
-liftF "shiftLeftByte" "SDL_imageFilterLeftByte"
+liftF "shiftLeftByte" "SDL_imageFilterShiftLeftByte"
   [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> IO CInt|]
 
-liftF "shiftLeftUInt" "SDL_imageFilterLeftUint"
+liftF "shiftLeftUInt" "SDL_imageFilterShiftLeftUint"
   [t|Ptr CUChar -> Ptr CUChar -> CUInt -> CUChar -> IO CInt|]
 
 liftF "shiftLeft" "SDL_imageFilterShiftLeft"

--- a/src/SDL/Raw/Primitive.hsc
+++ b/src/SDL/Raw/Primitive.hsc
@@ -171,8 +171,8 @@ liftF "aaPolygon" "aapolygonRGBA"
 liftF "filledPolygon" "filledPolygonRGBA"
   [t|Renderer -> Ptr X -> Ptr Y -> N -> R -> G -> B -> A -> IO CInt|]
 
-liftF "texturedPolygon" "texturedPolygonRGBA"
-  [t|Renderer -> Ptr X -> Ptr Y -> N -> Ptr Surface -> X -> Y -> R -> G -> B -> A -> IO CInt|]
+liftF "texturedPolygon" "texturedPolygon"
+  [t|Renderer -> Ptr X -> Ptr Y -> N -> Ptr Surface -> X -> Y -> IO CInt|]
 
 liftF "bezier" "bezierRGBA"
   [t|Renderer -> Ptr X -> Ptr Y -> N -> N -> R -> G -> B -> A -> IO CInt|]

--- a/src/SDL/Raw/Rotozoom.hsc
+++ b/src/SDL/Raw/Rotozoom.hsc
@@ -45,16 +45,16 @@ liftF "rotozoom" "rotozoomSurface"
 liftF "rotozoomXY" "rotozoomSurfaceXY"
   [t|Ptr Surface -> CDouble -> CDouble -> CDouble -> CInt -> IO (Ptr Surface)|]
 
-liftF "rotozoomSize" "rotozoomSize"
+liftF "rotozoomSize" "rotozoomSurfaceSize"
   [t|CInt -> CInt -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
 
-liftF "rotozoomSizeXY" "rotozoomSizeXY"
+liftF "rotozoomSizeXY" "rotozoomSurfaceSizeXY"
   [t|CInt -> CInt -> CDouble -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
 
 liftF "zoom" "zoomSurface"
   [t|Ptr Surface -> CDouble -> CDouble -> CInt -> IO (Ptr Surface)|]
 
-liftF "zoomSize" "zoomSize"
+liftF "zoomSize" "zoomSurfaceSize"
   [t|CInt -> CInt -> CDouble -> CDouble -> Ptr CInt -> Ptr CInt -> IO ()|]
 
 liftF "shrink" "shrinkSurface"


### PR DESCRIPTION
Some of the function names have been changed in SDL2_gfx. Update foreign function names to match SDL2_gfx version 1.0.4. The example executable builds and runs as expected. This is a proper solution to the workaround provided in #8.