### PR TITLE
Incorporate the specifiedPlainTV compatibility fix for TH 2.17 (#12) 

### DIFF
--- a/sdl2-gfx.cabal
+++ b/sdl2-gfx.cabal
@@ -44,7 +44,8 @@ library
     lifted-base      >= 0.2,
     monad-control    >= 1.0,
     sdl2             >= 2.0,
-    template-haskell,
+    template-haskell >=2.8 && <3,
+    template-haskell-compat-v0208 >=0.1.4 && <2,
     text,
     vector           >= 0.10.9.0
 

--- a/src/SDL/Raw/Helper.hs
+++ b/src/SDL/Raw/Helper.hs
@@ -20,6 +20,7 @@ module SDL.Raw.Helper (liftF) where
 import Control.Monad           (replicateM)
 import Control.Monad.IO.Class  (MonadIO, liftIO)
 import Language.Haskell.TH
+import qualified TemplateHaskell.Compat.V0208 as Compat
 
 -- | Given a name @fname@, a name of a C function @cname@ and the desired
 -- Haskell type @ftype@, this function generates:
@@ -81,7 +82,7 @@ liftType = \case
     m <- newName "m"
     return $
       ForallT
-        [PlainTV m]
+        [Compat.specifiedPlainTV m]
         [AppT (ConT ''MonadIO) $ VarT m]
         (AppT (VarT m) t)
   t -> return t

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-7.18
+resolver: lts-21.25
 system-ghc: true


### PR DESCRIPTION
Tested with cabal-install 3.10.2.1 with GHC 9.8.1 and stack 2.15.1 with lts-21.25.

Related issue: https://github.com/haskell-game/sdl2-gfx/issues/12

P.S. I updated the snapshot version in stack.yaml, so bump version might be necessary, although this package is not released on Hackage at the moment.